### PR TITLE
add FM_SFD to format option

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -13,14 +13,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - name: Setup Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.x'
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Checkout adafruit/ci-arduino
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
          repository: adafruit/ci-arduino
          path: ci

--- a/examples/SdFat_format/SdFat_format.ino
+++ b/examples/SdFat_format/SdFat_format.ino
@@ -70,7 +70,7 @@ void setup() {
   Serial.println("Creating and formatting FAT filesystem (this takes ~60 seconds)...");
 
   // Make filesystem.
-  FRESULT r = f_mkfs("", FM_FAT, 0, workbuf, sizeof(workbuf));
+  FRESULT r = f_mkfs("", FM_FAT | FM_SFD, 0, workbuf, sizeof(workbuf));
   if (r != FR_OK) {
     Serial.print("Error, f_mkfs failed with error code: "); Serial.println(r, DEC);
     while(1) yield();

--- a/examples/SdFat_format/SdFat_format.ino
+++ b/examples/SdFat_format/SdFat_format.ino
@@ -23,7 +23,10 @@
 #include "Adafruit_InternalFlash.h"
 
 // Since SdFat doesn't fully support FAT12 such as format a new flash
-// We will use Elm Cham's fatfs f_mkfs() to format
+// We will use Elm Cham's fatfs f_mkfs() to format. Note:
+// - FM_FAT: create with MBR (63 sectors). For CircuitPython compatibility, this is preferred since CPY simulate MBR.
+// However, disk size maybe need to be at least 192 sector (96KB)
+// - FM_FAT | FM_SFD: create without MBR, save 63 sectors. Disk size can be 128 sector (64KB).
 #include "ff.h"
 #include "diskio.h"
 
@@ -69,7 +72,7 @@ void setup() {
   // Call fatfs begin and passed flash object to initialize file system
   Serial.println("Creating and formatting FAT filesystem (this takes ~60 seconds)...");
 
-  // Make filesystem.
+  // Make filesystem: change FM_SFD (above note) to match your usage
   FRESULT r = f_mkfs("", FM_FAT | FM_SFD, 0, workbuf, sizeof(workbuf));
   if (r != FR_OK) {
     Serial.print("Error, f_mkfs failed with error code: "); Serial.println(r, DEC);


### PR DESCRIPTION
add FM_SFD to skip MBR, fix #3 add more note for this option
- FM_FAT: create with MBR (63 sectors). For CircuitPython compatibility, this is preferred since CPY simulate MBR. However, disk size maybe need to be at least 192 sector (96KB)
- FM_FAT | FM_SFD: create without MBR, save 63 sectors. Disk size can be 128 sector (64KB).